### PR TITLE
try to update to 6.0.0-GA

### DIFF
--- a/apm-dist/bin/oapServiceInit.bat
+++ b/apm-dist/bin/oapServiceInit.bat
@@ -1,0 +1,37 @@
+@REM
+@REM  Licensed to the Apache Software Foundation (ASF) under one or more
+@REM  contributor license agreements.  See the NOTICE file distributed with
+@REM  this work for additional information regarding copyright ownership.
+@REM  The ASF licenses this file to You under the Apache License, Version 2.0
+@REM  (the "License"); you may not use this file except in compliance with
+@REM  the License.  You may obtain a copy of the License at
+@REM
+@REM      http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM  Unless required by applicable law or agreed to in writing, software
+@REM  distributed under the License is distributed on an "AS IS" BASIS,
+@REM  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM  See the License for the specific language governing permissions and
+@REM  limitations under the License.
+
+@echo off
+
+setlocal
+set OAP_PROCESS_TITLE=Skywalking-Collector
+set OAP_HOME=%~dp0%..
+set OAP_OPTS="-Xms256M -Xmx512M -Doap.logDir=%OAP_HOME%\logs"
+
+set CLASSPATH=%OAP_HOME%\config;.;
+set CLASSPATH=%OAP_HOME%\oap-libs\*;%CLASSPATH%
+
+if defined JAVA_HOME (
+ set _EXECJAVA="%JAVA_HOME%\bin\java"
+)
+
+if not defined JAVA_HOME (
+ echo "JAVA_HOME not set."
+ set _EXECJAVA=java
+)
+
+start "%OAP_PROCESS_TITLE%" %_EXECJAVA% "%OAP_OPTS%" -cp "%CLASSPATH%" -Dmode=init org.apache.skywalking.oap.server.starter.OAPServerStartUp
+endlocal

--- a/apm-dist/bin/oapServiceInit.sh
+++ b/apm-dist/bin/oapServiceInit.sh
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env sh
+
+PRG="$0"
+PRGDIR=`dirname "$PRG"`
+[ -z "$OAP_HOME" ] && OAP_HOME=`cd "$PRGDIR/.." >/dev/null; pwd`
+
+OAP_LOG_DIR="${OAP_HOME}/logs"
+JAVA_OPTS=" -Xms256M -Xmx512M"
+
+if [ ! -d "${OAP_HOME}/logs" ]; then
+    mkdir -p "${OAP_LOG_DIR}"
+fi
+
+_RUNJAVA=${JAVA_HOME}/bin/java
+[ -z "$JAVA_HOME" ] && _RUNJAVA=java
+
+CLASSPATH="$OAP_HOME/config:$CLASSPATH"
+for i in "$OAP_HOME"/oap-libs/*.jar
+do
+    CLASSPATH="$i:$CLASSPATH"
+done
+
+OAP_OPTIONS=" -Doap.logDir=${OAP_LOG_DIR}"
+
+eval exec "\"$_RUNJAVA\" ${JAVA_OPTS} ${OAP_OPTIONS} -classpath $CLASSPATH -Dmode=init org.apache.skywalking.oap.server.starter.OAPServerStartUp \
+        2>${OAP_LOG_DIR}/oap.log 1> /dev/null &"
+
+if [ $? -eq 0 ]; then
+    sleep 1
+	echo "SkyWalking OAP started successfully!"
+else
+	echo "SkyWalking OAP started failure!"
+	exit 1
+fi

--- a/apm-dist/bin/oapServiceNoInit.bat
+++ b/apm-dist/bin/oapServiceNoInit.bat
@@ -1,0 +1,37 @@
+@REM
+@REM  Licensed to the Apache Software Foundation (ASF) under one or more
+@REM  contributor license agreements.  See the NOTICE file distributed with
+@REM  this work for additional information regarding copyright ownership.
+@REM  The ASF licenses this file to You under the Apache License, Version 2.0
+@REM  (the "License"); you may not use this file except in compliance with
+@REM  the License.  You may obtain a copy of the License at
+@REM
+@REM      http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM  Unless required by applicable law or agreed to in writing, software
+@REM  distributed under the License is distributed on an "AS IS" BASIS,
+@REM  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM  See the License for the specific language governing permissions and
+@REM  limitations under the License.
+
+@echo off
+
+setlocal
+set OAP_PROCESS_TITLE=Skywalking-Collector
+set OAP_HOME=%~dp0%..
+set OAP_OPTS="-Xms256M -Xmx512M -Doap.logDir=%OAP_HOME%\logs"
+
+set CLASSPATH=%OAP_HOME%\config;.;
+set CLASSPATH=%OAP_HOME%\oap-libs\*;%CLASSPATH%
+
+if defined JAVA_HOME (
+ set _EXECJAVA="%JAVA_HOME%\bin\java"
+)
+
+if not defined JAVA_HOME (
+ echo "JAVA_HOME not set."
+ set _EXECJAVA=java
+)
+
+start "%OAP_PROCESS_TITLE%" %_EXECJAVA% "%OAP_OPTS%" -cp "%CLASSPATH%" -Dmode=no-init org.apache.skywalking.oap.server.starter.OAPServerStartUp
+endlocal

--- a/apm-dist/bin/oapServiceNoInit.sh
+++ b/apm-dist/bin/oapServiceNoInit.sh
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env sh
+
+PRG="$0"
+PRGDIR=`dirname "$PRG"`
+[ -z "$OAP_HOME" ] && OAP_HOME=`cd "$PRGDIR/.." >/dev/null; pwd`
+
+OAP_LOG_DIR="${OAP_HOME}/logs"
+JAVA_OPTS=" -Xms256M -Xmx512M"
+
+if [ ! -d "${OAP_HOME}/logs" ]; then
+    mkdir -p "${OAP_LOG_DIR}"
+fi
+
+_RUNJAVA=${JAVA_HOME}/bin/java
+[ -z "$JAVA_HOME" ] && _RUNJAVA=java
+
+CLASSPATH="$OAP_HOME/config:$CLASSPATH"
+for i in "$OAP_HOME"/oap-libs/*.jar
+do
+    CLASSPATH="$i:$CLASSPATH"
+done
+
+OAP_OPTIONS=" -Doap.logDir=${OAP_LOG_DIR}"
+
+eval exec "\"$_RUNJAVA\" ${JAVA_OPTS} ${OAP_OPTIONS} -classpath $CLASSPATH -Dmode=no-init org.apache.skywalking.oap.server.starter.OAPServerStartUp \
+        2>${OAP_LOG_DIR}/oap.log 1> /dev/null &"
+
+if [ $? -eq 0 ]; then
+    sleep 1
+	echo "SkyWalking OAP started successfully!"
+else
+	echo "SkyWalking OAP started failure!"
+	exit 1
+fi

--- a/apm-dist/pom.xml
+++ b/apm-dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.0.0-beta</version>
+        <version>6.0.0-GA</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-dist/src/main/assembly/alarm-settings.yml
+++ b/apm-dist/src/main/assembly/alarm-settings.yml
@@ -24,7 +24,7 @@ rules:
     period: 10
     count: 3
     silence-period: 5
-    message: Response time of service {name} is more than 1000ms in last 3 minutes.
+    message: Response time of service {name} is more than 1000ms in 3 minutes of last 10 minutes.
   service_sla_rule:
     # Indicator value need to be long, double or int
     indicator-name: service_sla
@@ -36,7 +36,7 @@ rules:
     count: 2
     # How many times of checks, the alarm keeps silence after alarm triggered, default as same as period.
     silence-period: 3
-    message: Successful rate of service {name} is lower than 80% in last 2 minutes.
+    message: Successful rate of service {name} is lower than 80% in 2 minutes of last 10 minutes
   service_p90_sla_rule:
     # Indicator value need to be long, double or int
     indicator-name: service_p90
@@ -45,7 +45,7 @@ rules:
     period: 10
     count: 3
     silence-period: 5
-    message: 90% response time of service {name} is lower than 1000ms in last 3 minutes
+    message: 90% response time of service {name} is lower than 1000ms in 3 minutes of last 10 minutes
   service_instance_resp_time_rule:
     indicator-name: service_instance_resp_time
     op: ">"
@@ -53,7 +53,7 @@ rules:
     period: 10
     count: 2
     silence-period: 5
-    message: Response time of service instance {name} is more than 1000ms in last 2 minutes.
+    message: Response time of service instance {name} is more than 1000ms in 2 minutes of last 10 minutes
 #  Active endpoint related metric alarm will cost more memory than service and service instance metric alarm.
 #  Because the number of endpoint is much more than service and instance.
 #
@@ -64,7 +64,7 @@ rules:
 #    period: 10
 #    count: 2
 #    silence-period: 5
-#    message: Response time of endpoint {name} is more than 1000ms in last 2 minutes.
+#    message: Response time of endpoint {name} is more than 1000ms in 2 minutes of last 10 minutes
 
 webhooks:
 #  - http://127.0.0.1/notify/

--- a/apm-dist/src/main/assembly/application.yml
+++ b/apm-dist/src/main/assembly/application.yml
@@ -16,68 +16,85 @@
 
 cluster:
   standalone:
+  # Please check your ZooKeeper is 3.5+, However, it is also compatible with ZooKeeper 3.4.x. Replace the ZooKeeper 3.5+
+  # library the oap-libs folder with your ZooKeeper 3.4.x library.
 #  zookeeper:
-#    hostPort: localhost:2181
-#    # Retry Policy
-#    baseSleepTimeMs: 1000 # initial amount of time to wait between retries
-#    maxRetries: 3 # max number of times to retry
+#    nameSpace: ${SW_NAMESPACE:""}
+#    hostPort: ${SW_CLUSTER_ZK_HOST_PORT:localhost:2181}
+#    #Retry Policy
+#    baseSleepTimeMs: ${SW_CLUSTER_ZK_SLEEP_TIME:1000} # initial amount of time to wait between retries
+#    maxRetries: ${SW_CLUSTER_ZK_MAX_RETRIES:3} # max number of times to retry
 #  kubernetes:
-#    watchTimeoutSeconds: 60
-#    namespace: default
-#    labelSelector: app=collector,release=skywalking
-#    uidEnvName: SKYWALKING_COLLECTOR_UID
+#    watchTimeoutSeconds: ${SW_CLUSTER_K8S_WATCH_TIMEOUT:60}
+#    namespace: ${SW_CLUSTER_K8S_NAMESPACE:default}
+#    labelSelector: ${SW_CLUSTER_K8S_LABEL:app=collector,release=skywalking}
+#    uidEnvName: ${SW_CLUSTER_K8S_UID:SKYWALKING_COLLECTOR_UID}
+#  consul:
+#    serviceName: ${SW_SERVICE_NAME:"SkyWalking_OAP_Cluster"}
+#     Consul cluster nodes, example: 10.0.0.1:8500,10.0.0.2:8500,10.0.0.3:8500
+#    hostPort: ${SW_CLUSTER_CONSUL_HOST_PORT:localhost:8500}
 core:
   default:
-    restHost: 0.0.0.0
-    restPort: 12800
-    restContextPath: /
-    gRPCHost: 0.0.0.0
-    gRPCPort: 11800
+    restHost: ${SW_CORE_REST_HOST:0.0.0.0}
+    restPort: ${SW_CORE_REST_PORT:12800}
+    restContextPath: ${SW_CORE_REST_CONTEXT_PATH:/}
+    gRPCHost: ${SW_CORE_GRPC_HOST:0.0.0.0}
+    gRPCPort: ${SW_CORE_GRPC_PORT:11800}
     downsampling:
     - Hour
     - Day
     - Month
     # Set a timeout on metric data. After the timeout has expired, the metric data will automatically be deleted.
-    recordDataTTL: 90 # Unit is minute
-    minuteMetricsDataTTL: 90 # Unit is minute
-    hourMetricsDataTTL: 36 # Unit is hour
-    dayMetricsDataTTL: 45 # Unit is day
-    monthMetricsDataTTL: 18 # Unit is month
+    recordDataTTL: ${SW_CORE_RECORD_DATA_TTL:90} # Unit is minute
+    minuteMetricsDataTTL: ${SW_CORE_MINUTE_METRIC_DATA_TTL:90} # Unit is minute
+    hourMetricsDataTTL: ${SW_CORE_HOUR_METRIC_DATA_TTL:36} # Unit is hour
+    dayMetricsDataTTL: ${SW_CORE_DAY_METRIC_DATA_TTL:45} # Unit is day
+    monthMetricsDataTTL: ${SW_CORE_MONTH_METRIC_DATA_TTL:18} # Unit is month
 storage:
-  #  h2:
-  #    driver: org.h2.jdbcx.JdbcDataSource
-  #    url: jdbc:h2:mem:skywalking-oap-db
-  #    user: sa
+#  h2:
+#    driver: ${SW_STORAGE_H2_DRIVER:org.h2.jdbcx.JdbcDataSource}
+#    url: ${SW_STORAGE_H2_URL:jdbc:h2:mem:skywalking-oap-db}
+#    user: ${SW_STORAGE_H2_USER:sa}
   elasticsearch-5x:
-    clusterName: OAPStorageCluster
-    clusterNodes: localhost:9300
-    indexShardsNumber: 2
-    indexReplicasNumber: 0
+    clusterName: ${SW_STORAGE_ES_CLUSTER_NAME:CollectorDBCluster}
+    # nameSpace: ${SW_NAMESPACE:""}
+    clusterNodes: ${SW_STORAGE_ES_CLUSTER_NODES:localhost:9300}
+    indexShardsNumber: ${SW_STORAGE_ES_INDEX_SHARDS_NUMBER:2}
+    indexReplicasNumber: ${SW_STORAGE_ES_INDEX_REPLICAS_NUMBER:0}
     # Batch process setting, refer to https://www.elastic.co/guide/en/elasticsearch/client/java-api/5.5/java-docs-bulk-processor.html
-    bulkActions: 2000 # Execute the bulk every 2000 requests
-    bulkSize: 20 # flush the bulk every 20mb
-    flushInterval: 10 # flush the bulk every 10 seconds whatever the number of requests
-    concurrentRequests: 2 # the number of concurrent requests
+    bulkActions: ${SW_STORAGE_ES_BULK_ACTIONS:2000} # Execute the bulk every 2000 requests
+    bulkSize: ${SW_STORAGE_ES_BULK_SIZE:20} # flush the bulk every 20mb
+    flushInterval: ${SW_STORAGE_ES_FLUSH_INTERVAL:10} # flush the bulk every 10 seconds whatever the number of requests
+    concurrentRequests: ${SW_STORAGE_ES_CONCURRENT_REQUESTS:2} # the number of concurrent requests
+#  mysql:
 receiver-register:
   default:
 receiver-trace:
   default:
-    bufferPath: ../trace-buffer/  # Path to trace buffer files, suggest to use absolute path
-    bufferOffsetMaxFileSize: 100 # Unit is MB
-    bufferDataMaxFileSize: 500 # Unit is MB
-    bufferFileCleanWhenRestart: false
+    bufferPath: ${SW_RECEIVER_BUFFER_PATH:../trace-buffer/}  # Path to trace buffer files, suggest to use absolute path
+    bufferOffsetMaxFileSize: ${SW_RECEIVER_BUFFER_OFFSET_MAX_FILE_SIZE:100} # Unit is MB
+    bufferDataMaxFileSize: ${SW_RECEIVER_BUFFER_DATA_MAX_FILE_SIZE:500} # Unit is MB
+    bufferFileCleanWhenRestart: ${SW_RECEIVER_BUFFER_FILE_CLEAN_WHEN_RESTART:false}
+    sampleRate: ${SW_TRACE_SAMPLE_RATE:10000} # The sample rate precision is 1/10000. 10000 means 100% sample in default.
 receiver-jvm:
   default:
-service-mesh:
-  default:
-    bufferPath: ../mesh-buffer/  # Path to mesh telemetry data buffer files, suggest to use absolute path
-    bufferOffsetMaxFileSize: 100 # Unit is MB
-    bufferDataMaxFileSize: 500 # Unit is MB
-    bufferFileCleanWhenRestart: false
-istio-telemetry:
-  default:
+#service-mesh:
+#  default:
+#    bufferPath: ${SW_SERVICE_MESH_BUFFER_PATH:../mesh-buffer/}  # Path to trace buffer files, suggest to use absolute path
+#    bufferOffsetMaxFileSize: ${SW_SERVICE_MESH_OFFSET_MAX_FILE_SIZE:100} # Unit is MB
+#    bufferDataMaxFileSize: ${SW_SERVICE_MESH_BUFFER_DATA_MAX_FILE_SIZE:500} # Unit is MB
+#    bufferFileCleanWhenRestart: ${SW_SERVICE_MESH_BUFFER_FILE_CLEAN_WHEN_RESTART:false}
+#istio-telemetry:
+#  default:
+#receiver_zipkin:
+#  default:
+#    host: ${SW_RECEIVER_ZIPKIN_HOST:0.0.0.0}
+#    port: ${SW_RECEIVER_ZIPKIN_PORT:9411}
+#    contextPath: ${SW_RECEIVER_ZIPKIN_CONTEXT_PATH:/}
 query:
   graphql:
-    path: /graphql
+    path: ${SW_QUERY_GRAPHQL_PATH:/graphql}
 alarm:
   default:
+telemetry:
+  none:

--- a/apm-dist/src/main/assembly/component-libraries.yml
+++ b/apm-dist/src/main/assembly/component-libraries.yml
@@ -129,6 +129,9 @@ h2-jdbc-driver:
 mysql-connector-java:
   id: 33
   languages: Java
+ojdbc:
+  id: 34
+  languages: Java
 Spymemcached:
   id: 35
   languages: Java
@@ -177,6 +180,25 @@ http:
 rpc:
   id: 50
   languages: Java,C#,Node.js
+RabbitMQ:
+  id: 51
+  languages: Java
+rabbitmq-producer:
+  id: 52
+  languages: Java
+rabbitmq-consumer:
+  id: 53
+  languages: Java
+Canal:
+  id: 54
+  languages: Java
+Gson:
+  id: 55
+  languages: Java
+Redisson:
+  id: 56
+  languages: Java
+
 
 # .NET/.NET Core components
 # [3000, 4000) for C#/.NET only
@@ -252,6 +274,8 @@ Component-Server-Mappings:
   kafka-consumer: Kafka
   activemq-producer: ActiveMQ
   activemq-consumer: ActiveMQ
+  rabbitmq-producer: RabbitMQ
+  rabbitmq-consumer: RabbitMQ
   postgresql-jdbc-driver: PostgreSQL
   Xmemcached: Memcached
   Spymemcached: Memcached
@@ -259,6 +283,7 @@ Component-Server-Mappings:
   mysql-connector-java: Mysql
   Jedis: Redis
   StackExchange.Redis: Redis
+  Redisson: Redis
   SqlClient: SqlServer
   Npgsql: PostgreSQL
   MySqlConnector: Mysql

--- a/apm-dist/src/main/assembly/datasource-settings.properties
+++ b/apm-dist/src/main/assembly/datasource-settings.properties
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+jdbcUrl=jdbc:mysql://localhost:3306/swtest
+dataSource.user=root
+dataSource.password=root@1234
+dataSource.cachePrepStmts=true
+dataSource.prepStmtCacheSize=250
+dataSource.prepStmtCacheSqlLimit=2048
+dataSource.useServerPrepStmts=true
+dataSource.useLocalSessionState=true
+dataSource.rewriteBatchedStatements=true
+dataSource.cacheResultSetMetadata=true
+dataSource.cacheServerConfiguration=true
+dataSource.elideSetAutoCommits=true
+dataSource.maintainTimeStats=false

--- a/apm-dist/src/main/assembly/log4j2.xml
+++ b/apm-dist/src/main/assembly/log4j2.xml
@@ -25,7 +25,7 @@
         <RollingFile name="RollingFile" fileName="${log-path}/skywalking-oap-server.log"
                      filePattern="${log-path}/skywalking-oap-server-%d{yyyy-MM-dd}-%i.log" >
             <PatternLayout>
-                <pattern>%d - %c -%-4r [%t] %-5p %x - %m%n</pattern>
+                <pattern>%d - %c - %L [%t] %-5p %x - %m%n</pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="102400KB" />

--- a/apm-webapp/pom.xml
+++ b/apm-webapp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.0.0-beta</version>
+        <version>6.0.0-GA</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,7 +18,7 @@
         <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
 
         <ui.path>${project.parent.basedir}/skywalking-ui</ui.path>
-        <webapp.version>6.0.0-beta</webapp.version>
+        <webapp.version>6.0.0-GA</webapp.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>apm</artifactId>
-    <version>6.0.0-beta</version>
+    <version>6.0.0-GA</version>
     <modules>
         <module>apm-webapp</module>
         <module>storage-elasticsearch5x-plugin</module>
@@ -49,7 +49,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler.version>1.8</compiler.version>
-        <core.version>6.0.0-beta</core.version>
+        <core.version>6.0.0-GA</core.version>
         <lombok.version>1.18.0</lombok.version>
         <jackson.version>2.8.8</jackson.version>
         <elasticsearch.version>5.5.2</elasticsearch.version>

--- a/storage-elasticsearch5x-plugin/pom.xml
+++ b/storage-elasticsearch5x-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>6.0.0-beta</version>
+        <version>6.0.0-GA</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/storage-elasticsearch5x-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch5x/StorageModuleElasticsearchProvider.java
+++ b/storage-elasticsearch5x-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch5x/StorageModuleElasticsearchProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.skywalking.oap.server.storage.plugin.elasticsearch5x;
 
+import org.apache.skywalking.oap.server.core.CoreModule;
 import org.apache.skywalking.oap.server.core.storage.*;
 import org.apache.skywalking.oap.server.core.storage.cache.*;
 import org.apache.skywalking.oap.server.core.storage.query.*;
@@ -102,6 +103,6 @@ public class StorageModuleElasticsearchProvider extends ModuleProvider {
 
     @Override
     public String[] requiredModules() {
-        return new String[0];
+        return new String[]{ CoreModule.NAME};
     }
 }

--- a/storage-elasticsearch5x-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch5x/query/MetadataQueryEsDAO.java
+++ b/storage-elasticsearch5x-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch5x/query/MetadataQueryEsDAO.java
@@ -193,39 +193,29 @@ public class MetadataQueryEsDAO extends EsDAO implements IMetadataQueryDAO {
 
             ServiceInstance serviceInstance = new ServiceInstance();
             serviceInstance.setId(String.valueOf(sourceAsMap.get(ServiceInstanceInventory.SEQUENCE)));
-            serviceInstance.setName((String)sourceAsMap.get(ServiceInstanceInventory.NAME));
-            String propertiesString = (String)sourceAsMap.get(ServiceInstanceInventory.PROPERTIES);
-
-
-            if (!Strings.isNullOrEmpty(propertiesString)) {
-                JsonObject properties = GSON.fromJson(propertiesString, JsonObject.class);
-                if (properties.has(LANGUAGE)) {
-                    serviceInstance.setLanguage(LanguageTrans.INSTANCE.value(properties.get(LANGUAGE).getAsString()));
-                } else {
-                    serviceInstance.setLanguage(Language.UNKNOWN);
-                }
-
-                if (properties.has(OS_NAME)) {
-                    serviceInstance.getAttributes().add(new Attribute(OS_NAME, properties.get(OS_NAME).getAsString()));
-                }
-                if (properties.has(HOST_NAME)) {
-                    serviceInstance.getAttributes().add(new Attribute(HOST_NAME, properties.get(HOST_NAME).getAsString()));
-                }
-                if (properties.has(PROCESS_NO)) {
-                    serviceInstance.getAttributes().add(new Attribute(PROCESS_NO, properties.get(PROCESS_NO).getAsString()));
-                }
-                if (properties.has(IPV4S)) {
-                    List<String> ipv4s = ServiceInstanceInventory.PropertyUtil.ipv4sDeserialize(properties.get(IPV4S).getAsString());
-                    for (String ipv4 : ipv4s) {
-                        serviceInstance.getAttributes().add(new Attribute(ServiceInstanceInventory.PropertyUtil.IPV4S, ipv4));
-                    }
-                }
-            } else {
+            serviceInstance.setName((String) sourceAsMap.get(ServiceInstanceInventory.NAME));
+            String languageId = ((String) sourceAsMap.get(ServiceInstanceInventory.PropertyUtil.LANGUAGE));
+            if(!Strings.isNullOrEmpty(languageId)) {
+                serviceInstance.setLanguage(LanguageTrans.INSTANCE.value(languageId));
+            }else {
                 serviceInstance.setLanguage(Language.UNKNOWN);
+            }
+            String osName = (String) sourceAsMap.get(ServiceInstanceInventory.PropertyUtil.OS_NAME);
+            if (!Strings.isNullOrEmpty(osName)) {
+                serviceInstance.getAttributes().add(new Attribute(ServiceInstanceInventory.PropertyUtil.OS_NAME, osName));
+            }
+            String hostName = (String) sourceAsMap.get(ServiceInstanceInventory.PropertyUtil.HOST_NAME);
+            if (!Strings.isNullOrEmpty(hostName)) {
+                serviceInstance.getAttributes().add(new Attribute(ServiceInstanceInventory.PropertyUtil.HOST_NAME, hostName));
+            }
+            serviceInstance.getAttributes().add(new Attribute(ServiceInstanceInventory.PropertyUtil.PROCESS_NO, String.valueOf(((Number) sourceAsMap.get(ServiceInstanceInventory.PropertyUtil.PROCESS_NO)).intValue())));
+
+            List<String> ipv4s = ServiceInstanceInventory.PropertyUtil.ipv4sDeserialize((String) sourceAsMap.get(ServiceInstanceInventory.PropertyUtil.IPV4S));
+            for (String ipv4 : ipv4s) {
+                serviceInstance.getAttributes().add(new Attribute(ServiceInstanceInventory.PropertyUtil.IPV4S, ipv4));
             }
             serviceInstances.add(serviceInstance);
         }
-
         return serviceInstances;
     }
 


### PR DESCRIPTION
get error:

2019-02-03 15:48:58,201 - org.apache.skywalking.oap.server.library.module.BootstrapFlow - 54 [main] INFO  [] - start the provider default in receiver-jvm module.
2019-02-03 15:48:58,206 - org.apache.skywalking.oap.server.library.module.BootstrapFlow - 54 [main] INFO  [] - start the provider default in receiver-register module.
2019-02-03 15:48:58,345 - org.apache.skywalking.oap.server.library.server.jetty.JettyServer - 85 [main] INFO  [] - start server, host: 0.0.0.0, port: 12800
2019-02-03 15:48:58,351 - org.eclipse.jetty.server.Server - 372 [main] INFO  [] - jetty-9.4.2.v20170220
2019-02-03 15:48:58,405 - org.eclipse.jetty.server.handler.ContextHandler - 802 [main] INFO  [] - Started o.e.j.s.ServletContextHandler@200d1a3d{/,null,AVAILABLE}
2019-02-03 15:48:58,436 - org.eclipse.jetty.server.AbstractConnector - 280 [main] INFO  [] - Started ServerConnector@1600a8a2{HTTP/1.1,[http/1.1]}{0.0.0.0:12800}
2019-02-03 15:48:58,436 - org.eclipse.jetty.server.Server - 444 [main] INFO  [] - Started @10084ms
2019-02-03 15:48:58,438 - org.apache.skywalking.oap.server.core.storage.PersistenceTimer - 49 [main] INFO  [] - persistence timer start
2019-02-03 15:48:58,444 - org.apache.skywalking.oap.server.core.cache.CacheUpdateTimer - 42 [main] INFO  [] - Cache update timer start
2019-02-03 15:48:59,548 - org.apache.skywalking.oap.server.storage.plugin.elasticsearch5x.cache.ServiceInventoryCacheEsDAO - 110 [pool-11-thread-1] ERROR [] - no such index
org.elasticsearch.index.IndexNotFoundException: no such index
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.infe(IndexNameExpressionResolver.java:676) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.innerResolve(IndexNameExpressionResolver.java:630) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.resolve(IndexNameExpressionResolver.java:578) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndices(IndexNameExpressionResolver.java:168) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndices(IndexNameExpressionResolver.java:140) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.action.search.TransportSearchAction.executeSearch(TransportSearchAction.java:265) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.action.search.TransportSearchAction.doExecute(TransportSearchAction.java:188) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.action.search.TransportSearchAction.doExecute(TransportSearchAction.java:67) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:170) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:142) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.action.support.HandledTransportAction$TransportHandler.messageReceived(HandledTransportAction.java:64) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.action.support.HandledTransportAction$TransportHandler.messageReceived(HandledTransportAction.java:54) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:69) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.transport.TcpTransport$RequestHandler.doRun(TcpTransport.java:1556) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.common.util.concurrent.EsExecutors$1.execute(EsExecutors.java:110) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.transport.TcpTransport.handleRequest(TcpTransport.java:1513) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.transport.TcpTransport.messageReceived(TcpTransport.java:1396) ~[elasticsearch-5.5.2.jar:5.5.2]
	at org.elasticsearch.transport.netty4.Netty4MessageChannelHandler.channelRead(Netty4MessageChannelHandler.java:74) ~[transport-netty4-client-5.5.2.jar:5.5.2]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) ~[netty-codec-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:297) ~[netty-codec-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:413) ~[netty-codec-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265) ~[netty-codec-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:86) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:241) ~[netty-handler-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1334) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:926) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:134) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:644) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysPlain(NioEventLoop.java:544) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:498) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:458) ~[netty-transport-4.1.27.Final.jar:4.1.27.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858) ~[netty-common-4.1.27.Final.jar:4.1.27.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_162]
